### PR TITLE
Adapts Java example to work with current Scribe API

### DIFF
--- a/java/src/com/xing/dev/XingExample.java
+++ b/java/src/com/xing/dev/XingExample.java
@@ -41,10 +41,9 @@ public class XingExample {
 
         // Initializing OAuth - Service
         OAuthService service = new ServiceBuilder()
-                .provider(XingApi.class)
                 .apiKey(apiKey)
                 .apiSecret(apiSecret)
-                .build();
+                .build(XingApi.instance());
 
         // Obtain the Request Token
         System.out.println("Fetching the Request Token...");

--- a/java/src/com/xing/dev/XingExample.java
+++ b/java/src/com/xing/dev/XingExample.java
@@ -2,10 +2,10 @@ package com.xing.dev;
 
 import java.util.Scanner;
 
-import org.scribe.builder.*;
-import org.scribe.builder.api.*;
-import org.scribe.model.*;
-import org.scribe.oauth.*;
+import com.github.scribejava.apis.XingApi;
+import com.github.scribejava.core.builder.*;
+import com.github.scribejava.core.model.*;
+import com.github.scribejava.core.oauth.*;
 
 public class XingExample {
 
@@ -40,14 +40,14 @@ public class XingExample {
         }
 
         // Initializing OAuth - Service
-        OAuthService service = new ServiceBuilder()
+        OAuth10aService service = new ServiceBuilder()
                 .apiKey(apiKey)
                 .apiSecret(apiSecret)
                 .build(XingApi.instance());
 
         // Obtain the Request Token
         System.out.println("Fetching the Request Token...");
-        Token requestToken = service.getRequestToken();
+        OAuth1RequestToken requestToken = service.getRequestToken();
         System.out.println("Got the Request Token!");
         System.out.println();
 
@@ -55,19 +55,19 @@ public class XingExample {
         System.out.println(service.getAuthorizationUrl(requestToken));
         System.out.println("And paste the verifier here");
         System.out.print(">> ");
-        Verifier verifier = new Verifier(input.nextLine());
+        String verifier = input.nextLine();
         System.out.println();
 
         // Trade the Request Token and Verfier for the Access Token
         System.out.println("Trading the Request Token for an Access Token...");
-        Token accessToken = service.getAccessToken(requestToken, verifier);
+        OAuth1AccessToken accessToken = service.getAccessToken(requestToken, verifier);
         System.out.println("Got the Access Token!");
         System.out.println("(if your curious it looks like this: " + accessToken + " )");
         System.out.println();
 
         // Now let's go and ask for a protected resource!
         System.out.println("Now we're going to access a protected resource...");
-        OAuthRequest request = new OAuthRequest(Verb.GET, callUrl);
+        OAuthRequest request = new OAuthRequest(Verb.GET, callUrl, service);
         service.signRequest(accessToken, request);
         Response response = request.send();
         System.out.println("Got it! Lets see what we found...");


### PR DESCRIPTION
The provider() method is not available in the current version of Scribe. I adapted the sample code to work with the current version of Scribe.
